### PR TITLE
fix: Update Biome configuration to v2.0.0 and fix React  warnings

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,7 +1,7 @@
 {
-  "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.0.0/schema.json",
   "files": {
-    "ignore": ["src/shadcn", "dist"],
+    "includes": ["**", "!**/src/shadcn", "!**/dist"],
     "ignoreUnknown": false
   },
   "formatter": {
@@ -32,9 +32,7 @@
   "linter": {
     "enabled": true,
     "rules": {
-      "all": true,
       "style": {
-        "all": true,
         "useFilenamingConvention": {
           "level": "error",
           "options": {
@@ -42,10 +40,19 @@
             "requireAscii": true,
             "strictCase": true
           }
-        }
+        },
+        "noParameterAssign": "error",
+        "useAsConstAssertion": "error",
+        "useDefaultParameterLast": "error",
+        "useEnumInitializers": "error",
+        "useSelfClosingElements": "error",
+        "useSingleVarDeclarator": "error",
+        "noUnusedTemplateLiteral": "error",
+        "useNumberNamespace": "error",
+        "noInferrableTypes": "error",
+        "noUselessElse": "error"
       },
       "nursery": {
-        "all": true,
         "useSortedClasses": {
           "level": "warn",
           "fix": "safe",
@@ -53,7 +60,6 @@
         }
       },
       "suspicious": {
-        "all": true,
         "noConsole": {
           "level": "warn",
           "options": {
@@ -73,9 +79,7 @@
       }
     }
   },
-  "organizeImports": {
-    "enabled": true
-  },
+  "assist": { "actions": { "source": { "organizeImports": "on" } } },
 
   "vcs": {
     "clientKind": "git",
@@ -84,7 +88,7 @@
   },
   "overrides": [
     {
-      "include": ["tailwind.config.cjs"],
+      "includes": ["**/tailwind.config.cjs"],
       "linter": {
         "rules": {
           "style": {
@@ -97,7 +101,7 @@
       }
     },
     {
-      "include": ["src/vite-env.d.ts", "src/context"],
+      "includes": ["**/src/vite-env.d.ts", "**/src/context/**"],
       "linter": {
         "rules": {
           "style": {

--- a/package.json
+++ b/package.json
@@ -62,5 +62,10 @@
   },
   "type": "module",
   "version": "0.0.1",
-  "trustedDependencies": ["@biomejs/biome", "@parcel/watcher", "core-js", "esbuild"]
+  "trustedDependencies": [
+    "@biomejs/biome",
+    "@parcel/watcher",
+    "core-js",
+    "esbuild"
+  ]
 }

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1,12 +1,12 @@
+import type { JSX } from 'react';
+import { useEffect } from 'react';
+import { Route, Routes, useLocation } from 'react-router-dom';
 import { Layout } from '@/components/Layout';
 import { ThemeProvider } from '@/components/ThemeProvider';
 import { APP_CONFIG } from '@/config';
 import { defaultRoute, routes } from '@/routes';
 import { SidebarProvider } from '@/shadcn/components/ui/sidebar';
 import { Toaster } from '@/shadcn/components/ui/sonner';
-import { useEffect } from 'react';
-import type { JSX } from 'react';
-import { Route, Routes, useLocation } from 'react-router-dom';
 
 function App(): JSX.Element {
   const location = useLocation();

--- a/src/components/ActionSection.tsx
+++ b/src/components/ActionSection.tsx
@@ -1,6 +1,6 @@
-import { Button } from '@/shadcn/components/ui/button';
 import type React from 'react';
 import type { JSX } from 'react';
+import { Button } from '@/shadcn/components/ui/button';
 
 interface ActionSectionProps {
   children: React.ReactNode;

--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -1,3 +1,6 @@
+import type { JSX } from 'react';
+import React from 'react';
+import { Link, useLocation } from 'react-router-dom';
 import { APP_CONFIG } from '@/config';
 import { type Route, routes } from '@/routes';
 import {
@@ -7,10 +10,6 @@ import {
   SidebarMenuItem,
   SidebarSeparator
 } from '@/shadcn/components/ui/sidebar';
-import React from 'react';
-import type { JSX } from 'react';
-import { useLocation } from 'react-router-dom';
-import { Link } from 'react-router-dom';
 
 const SidebarRouteItem: React.FC<{ route: Route }> = ({ route }) => {
   const location = useLocation();

--- a/src/components/FieldSelector.tsx
+++ b/src/components/FieldSelector.tsx
@@ -1,5 +1,5 @@
-import { Label } from '@/components/Label';
 import type { JSX } from 'react';
+import { Label } from '@/components/Label';
 
 import {
   Select,
@@ -8,6 +8,7 @@ import {
   SelectTrigger,
   SelectValue
 } from '@/shadcn/components/ui/select';
+
 interface FieldSelectorProps {
   fields: string[];
   selectedField: string;

--- a/src/components/FileUpload.tsx
+++ b/src/components/FileUpload.tsx
@@ -1,7 +1,8 @@
-import { Button } from '@/shadcn/components/ui/button';
-import type { FileType } from '@/store/store';
 import type React from 'react';
 import type { JSX } from 'react';
+import { Button } from '@/shadcn/components/ui/button';
+import type { FileType } from '@/store/store';
+
 type FileUploadProps = {
   onFileUpload: (fileName: string, fileContent: string, fileType: FileType) => void;
   fileName: string | null;

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,6 +1,6 @@
-import { Separator } from '@/shadcn/components/ui/separator';
 import type React from 'react';
 import type { JSX } from 'react';
+import { Separator } from '@/shadcn/components/ui/separator';
 
 interface HeaderProps {
   children: React.ReactNode;

--- a/src/components/HelpTooltip.tsx
+++ b/src/components/HelpTooltip.tsx
@@ -1,3 +1,4 @@
+import { HelpCircle } from 'lucide-react';
 import {
   Tooltip,
   TooltipContent,
@@ -5,7 +6,6 @@ import {
   TooltipTrigger
 } from '@/shadcn/components/ui/tooltip';
 import { cn } from '@/shadcn/lib/utils';
-import { HelpCircle } from 'lucide-react';
 
 interface HelpTooltipProps {
   message: string;

--- a/src/components/Label.tsx
+++ b/src/components/Label.tsx
@@ -1,5 +1,4 @@
-import type { ReactNode } from 'react';
-import type { JSX } from 'react';
+import type { JSX, ReactNode } from 'react';
 
 type LabelProps = {
   htmlFor: string;

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,7 +1,7 @@
-import { AppSidebar } from '@/components/AppSidebar';
-import { WorkingFileDownloader } from '@/components/WorkingFileDownloader';
 import type { JSX } from 'react';
 import { Outlet } from 'react-router-dom';
+import { AppSidebar } from '@/components/AppSidebar';
+import { WorkingFileDownloader } from '@/components/WorkingFileDownloader';
 
 export function Layout(): JSX.Element {
   return (

--- a/src/components/PageTitle.tsx
+++ b/src/components/PageTitle.tsx
@@ -1,5 +1,5 @@
-import { APP_CONFIG } from '@/config';
 import { useEffect } from 'react';
+import { APP_CONFIG } from '@/config';
 
 interface PageTitleProps {
   title: string;

--- a/src/components/ThemeProvider.tsx
+++ b/src/components/ThemeProvider.tsx
@@ -1,6 +1,6 @@
-import { type Theme, ThemeProviderContext } from '@/context/ThemeContext';
-import { useEffect, useState } from 'react';
 import type { JSX } from 'react';
+import { useEffect, useState } from 'react';
+import { type Theme, ThemeProviderContext } from '@/context/ThemeContext';
 
 type ThemeProviderProps = {
   children: React.ReactNode;

--- a/src/hooks/useFileUpload.ts
+++ b/src/hooks/useFileUpload.ts
@@ -1,6 +1,6 @@
-import { useReferenceFileStore, useWorkingFileStore } from '@/store/store';
-import type { FileType } from '@/store/store';
 import { toast } from 'sonner';
+import type { FileType } from '@/store/store';
+import { useReferenceFileStore, useWorkingFileStore } from '@/store/store';
 
 export function useFileUpload(
   storeType: 'working' | 'reference'

--- a/src/hooks/useTheme.ts
+++ b/src/hooks/useTheme.ts
@@ -1,5 +1,5 @@
-import { ThemeProviderContext, type ThemeProviderState } from '@/context/ThemeContext';
 import { useContext } from 'react';
+import { ThemeProviderContext, type ThemeProviderState } from '@/context/ThemeContext';
 
 export const useTheme = (): ThemeProviderState => {
   const context = useContext(ThemeProviderContext);

--- a/src/lib/combine.test.ts
+++ b/src/lib/combine.test.ts
@@ -1,5 +1,5 @@
-import { type FileInfo, combineFiles } from '@/lib/combine';
 import { describe, expect, it } from 'vitest';
+import { combineFiles, type FileInfo } from '@/lib/combine';
 
 describe('combineFiles', () => {
   it('properly merges entries with same ID across files', () => {

--- a/src/lib/fileAnalysis.test.ts
+++ b/src/lib/fileAnalysis.test.ts
@@ -1,5 +1,5 @@
-import { analyzeField, analyzeFieldDetails } from '@/lib/fileAnalysis';
 import { describe, expect, it } from 'vitest';
+import { analyzeField, analyzeFieldDetails } from '@/lib/fileAnalysis';
 
 const REGEX_TEST = /regex/;
 

--- a/src/lib/parse.test.ts
+++ b/src/lib/parse.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from 'vitest';
 import {
   countCsvRows,
   csvToJson,
@@ -10,7 +11,7 @@ import {
   serializeJson
 } from '@/lib/parse';
 import type { FileType } from '@/store/store';
-import { describe, expect, it } from 'vitest';
+
 describe('CSV counting', () => {
   it('counts single row in csv file', () => {
     const singleRowCsv = 'name,age\nJohn,30';

--- a/src/lib/parse.ts
+++ b/src/lib/parse.ts
@@ -1,5 +1,6 @@
-import type { FileType } from '@/store/store';
 import Papa from 'papaparse';
+import type { FileType } from '@/store/store';
+
 const BOM_REGEX = /^\uFEFF/;
 const CRLF_REGEX = /\r\n/g;
 
@@ -38,7 +39,7 @@ export const getAllPaths = (obj: object, prefix = ''): string[] => {
   }
 
   for (const key in obj) {
-    if (Object.prototype.hasOwnProperty.call(obj, key)) {
+    if (Object.hasOwn(obj, key)) {
       const value = (obj as { [key: string]: unknown })[key];
       const newPath = prefix ? `${prefix}.${key}` : key;
 
@@ -125,7 +126,7 @@ export const flattenObject = (
       // Recursively flatten nested objects
       const flattened = flattenObject(obj[key] as Record<string, unknown>, prefixedKey);
       for (const key in flattened) {
-        if (Object.prototype.hasOwnProperty.call(flattened, key)) {
+        if (Object.hasOwn(flattened, key)) {
           acc[key] = flattened[key];
         }
       }

--- a/src/lib/uuid.test.ts
+++ b/src/lib/uuid.test.ts
@@ -1,5 +1,5 @@
-import { extractUuids, extractUuidsFromCsv, extractUuidsFromJsonl } from '@/lib/uuid';
 import { describe, expect, it } from 'vitest';
+import { extractUuids, extractUuidsFromCsv, extractUuidsFromJsonl } from '@/lib/uuid';
 
 describe('UUID extraction from text', () => {
   it('finds valid uuid in simple text', () => {

--- a/src/lib/uuid.ts
+++ b/src/lib/uuid.ts
@@ -1,5 +1,5 @@
-import { getValueByPath } from '@/lib/parse';
 import Papa from 'papaparse';
+import { getValueByPath } from '@/lib/parse';
 
 const UUID_REGEX =
   /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,9 +1,9 @@
 import './index.css';
 
-import App from '@/app';
 import React from 'react';
 import reactDom from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
+import App from '@/app';
 
 const rootElement = document.querySelector('#root');
 if (rootElement) {

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -1,6 +1,6 @@
-import { getParsedContentFromFile } from '@/lib/parse';
-import { type StoreApi, type UseBoundStore, create } from 'zustand';
+import { create, type StoreApi, type UseBoundStore } from 'zustand';
 import { immer } from 'zustand/middleware/immer';
+import { getParsedContentFromFile } from '@/lib/parse';
 // import type { WithImmer } from 'zustand/middleware';
 
 export type FileType = 'jsonl' | 'csv' | 'json' | 'unknown';

--- a/src/views/Backfill.tsx
+++ b/src/views/Backfill.tsx
@@ -1,3 +1,6 @@
+import type { JSX } from 'react';
+import { useEffect, useState } from 'react';
+import { toast } from 'sonner';
 import { ActionSection } from '@/components/ActionSection';
 import { FileUpload } from '@/components/FileUpload';
 import { Header } from '@/components/Header';
@@ -21,9 +24,6 @@ import {
   useReferenceFileStore,
   useWorkingFileStore
 } from '@/store/store';
-import { useEffect, useState } from 'react';
-import type { JSX } from 'react';
-import { toast } from 'sonner';
 
 export function Backfill(): JSX.Element {
   const { fileName: workingFileName, fileContentParsed: workingFileContent } =

--- a/src/views/Combine.tsx
+++ b/src/views/Combine.tsx
@@ -1,17 +1,17 @@
+import { Plus } from 'lucide-react';
+import type { JSX } from 'react';
+import { useState } from 'react';
+import { toast } from 'sonner';
 import { ActionSection } from '@/components/ActionSection';
 import { FieldSelector } from '@/components/FieldSelector';
 import { FileUpload } from '@/components/FileUpload';
 import { Header } from '@/components/Header';
 import { Section } from '@/components/Section';
-import { type FileInfo, combineFiles } from '@/lib/combine';
+import { combineFiles, type FileInfo } from '@/lib/combine';
 import { getParsedContentFromFile, serializeJson } from '@/lib/parse';
 import { Button } from '@/shadcn/components/ui/button';
 import { Input } from '@/shadcn/components/ui/input';
 import type { FileType } from '@/store/store';
-import { Plus } from 'lucide-react';
-import { useState } from 'react';
-import type { JSX } from 'react';
-import { toast } from 'sonner';
 
 export function Combine(): JSX.Element {
   const [files, setFiles] = useState<FileInfo[]>([

--- a/src/views/Convert.tsx
+++ b/src/views/Convert.tsx
@@ -1,3 +1,6 @@
+import type React from 'react';
+import { useState } from 'react';
+import { toast } from 'sonner';
 import { ActionSection } from '@/components/ActionSection';
 import { FileUpload } from '@/components/FileUpload';
 import { Header } from '@/components/Header';
@@ -12,9 +15,6 @@ import {
   SelectValue
 } from '@/shadcn/components/ui/select';
 import { type FileType, useWorkingFileStore } from '@/store/store';
-import type React from 'react';
-import { useState } from 'react';
-import { toast } from 'sonner';
 
 export function Convert(): React.JSX.Element {
   const { fileName, fileContentParsed } = useWorkingFileStore();

--- a/src/views/FieldRemover.tsx
+++ b/src/views/FieldRemover.tsx
@@ -1,3 +1,7 @@
+import { RefreshCw, X } from 'lucide-react';
+import type { JSX } from 'react';
+import { useEffect, useState } from 'react';
+import { toast } from 'sonner';
 import { ActionSection } from '@/components/ActionSection';
 import { FieldSelector } from '@/components/FieldSelector';
 import { FileUpload } from '@/components/FileUpload';
@@ -15,10 +19,6 @@ import {
   SelectValue
 } from '@/shadcn/components/ui/select';
 import { type FileType, useWorkingFileStore } from '@/store/store';
-import { RefreshCw, X } from 'lucide-react';
-import { useEffect, useState } from 'react';
-import type { JSX } from 'react';
-import { toast } from 'sonner';
 
 type ComparisonType =
   | 'equals'

--- a/src/views/Filter.tsx
+++ b/src/views/Filter.tsx
@@ -1,3 +1,7 @@
+import { RefreshCw, X } from 'lucide-react';
+import type { JSX } from 'react';
+import { useEffect, useState } from 'react';
+import { toast } from 'sonner';
 import { ActionSection } from '@/components/ActionSection';
 import { FieldSelector } from '@/components/FieldSelector';
 import { FileUpload } from '@/components/FileUpload';
@@ -21,10 +25,6 @@ import {
   SelectValue
 } from '@/shadcn/components/ui/select';
 import { type FileType, useWorkingFileStore } from '@/store/store';
-import { RefreshCw, X } from 'lucide-react';
-import { useEffect, useState } from 'react';
-import type { JSX } from 'react';
-import { toast } from 'sonner';
 
 type ComparisonType =
   | 'equals'

--- a/src/views/MapValues.tsx
+++ b/src/views/MapValues.tsx
@@ -1,3 +1,6 @@
+import type { JSX } from 'react';
+import { useState } from 'react';
+import { toast } from 'sonner';
 import { ActionSection } from '@/components/ActionSection';
 import { FieldSelector } from '@/components/FieldSelector';
 import { FileUpload } from '@/components/FileUpload';
@@ -7,9 +10,6 @@ import { useFileUpload } from '@/hooks/useFileUpload';
 import { getAllPaths, getValueByPath } from '@/lib/parse';
 import { Button } from '@/shadcn/components/ui/button';
 import { useWorkingFileStore } from '@/store/store';
-import { useState } from 'react';
-import type { JSX } from 'react';
-import { toast } from 'sonner';
 
 export function MapValues(): JSX.Element {
   const { fileContentParsed, fileName } = useWorkingFileStore();

--- a/src/views/Split.tsx
+++ b/src/views/Split.tsx
@@ -1,3 +1,7 @@
+import jsZip from 'jszip';
+import type { JSX } from 'react';
+import { useEffect, useState } from 'react';
+import { toast } from 'sonner';
 import { ActionSection } from '@/components/ActionSection';
 import { FieldSelector } from '@/components/FieldSelector';
 import { FileUpload } from '@/components/FileUpload';
@@ -6,10 +10,6 @@ import { Section } from '@/components/Section';
 import { useFileUpload } from '@/hooks/useFileUpload';
 import { getAllPaths, serializeJson } from '@/lib/parse';
 import { type FileType, useWorkingFileStore } from '@/store/store';
-import jsZip from 'jszip';
-import { useEffect, useState } from 'react';
-import type { JSX } from 'react';
-import { toast } from 'sonner';
 
 export function Split(): JSX.Element {
   const { fileName: workingFileName, fileContentParsed: workingFileContent } =

--- a/src/views/Stats.tsx
+++ b/src/views/Stats.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from 'react';
 import { FieldSelector } from '@/components/FieldSelector';
 import { FileUpload } from '@/components/FileUpload';
 import { Header } from '@/components/Header';
@@ -5,14 +6,13 @@ import { HelpTooltip } from '@/components/HelpTooltip';
 import { Section } from '@/components/Section';
 import { useFileUpload } from '@/hooks/useFileUpload';
 import {
-  type FieldAnalysisDetail,
   analyzeField,
-  analyzeFieldDetails
+  analyzeFieldDetails,
+  type FieldAnalysisDetail
 } from '@/lib/fileAnalysis';
 import { getAllPaths } from '@/lib/parse';
 import { ScrollArea } from '@/shadcn/components/ui/scroll-area';
 import { useWorkingFileStore } from '@/store/store';
-import { useEffect, useState } from 'react';
 
 interface FileStatisticsProps {
   fileName: string;

--- a/src/views/UuidExtractor.tsx
+++ b/src/views/UuidExtractor.tsx
@@ -1,3 +1,6 @@
+import type { JSX } from 'react';
+import { useMemo, useState } from 'react';
+import { toast } from 'sonner';
 import { ActionSection } from '@/components/ActionSection';
 import { FieldSelector } from '@/components/FieldSelector';
 import { FileUpload } from '@/components/FileUpload';
@@ -7,9 +10,6 @@ import { useFileUpload } from '@/hooks/useFileUpload';
 import { getAllPaths, getValueByPath } from '@/lib/parse';
 import { extractUuids } from '@/lib/uuid';
 import { useWorkingFileStore } from '@/store/store';
-import { useMemo, useState } from 'react';
-import type { JSX } from 'react';
-import { toast } from 'sonner';
 
 export function UuidExtractor(): JSX.Element {
   const { fileName, fileContentParsed } = useWorkingFileStore();


### PR DESCRIPTION
- Migrate Biome configuration from v1.9.4 to v2.0.0 schema
  - Update deprecated 'ignore' patterns to 'includes' with negations
  - Remove deprecated 'all: true' rule configurations
  - Update 'organizeImports' to new 'assist.actions.source.organizeImports' format
  - Fix 'include' to 'includes' in overrides sections
- Fix React component static ID warnings in Translate.tsx
  - Add useId hook import from React
  - Replace static htmlFor/id attributes with dynamically generated IDs
  - Ensures unique IDs when components are used multiple times
- Auto-format imports across all files to match new Biome rules